### PR TITLE
Fix: CORS 설정 변겅

### DIFF
--- a/src/main/java/kr/ac/knu/CapstoneDesignProject2/security/config/CorsConfig.java
+++ b/src/main/java/kr/ac/knu/CapstoneDesignProject2/security/config/CorsConfig.java
@@ -14,9 +14,10 @@ public class CorsConfig {
         UrlBasedCorsConfigurationSource source= new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOrigin("*");
+        // config.addAllowedOrigin("*");
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
+        config.addAllowedOriginPattern("*");
         source.registerCorsConfiguration("/**", config);
         return new CorsFilter(source);
     }


### PR DESCRIPTION
setAllowCredentials(true)를 시 ACAO 헤더를 달 수 없어 
addAllowedOrigin("*")이 동작하지 않던 경우 수정
